### PR TITLE
Disable Fly HTTP/2 backend to fix invalid request logs

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -18,7 +18,8 @@ primary_region = "atl"
   [http_service.http_options]
     response_timeout = 300
     idle_timeout = 300
-    h2_backend = true
+    # Gunicorn only speaks HTTP/1.1; disable HTTP/2 backend to avoid invalid preface requests
+    h2_backend = false
 
   [[http_service.checks]]
     interval = "30s"


### PR DESCRIPTION
## Summary
- disable Fly's HTTP/2 backend mode so the Gunicorn/Flask service receives HTTP/1.1 requests it can understand
- document the reason in fly.toml to avoid future regressions

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_69066db536d8832c845228f426145128