### PR TITLE
Increase upload limit to 150MB

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,8 +23,11 @@ import jwt
 # ---------------- Setup ----------------
 app = Flask(__name__)
 
-# Configure Flask for larger file uploads
-app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024  # 50MB limit
+# Configure Flask for larger file uploads. Some iOS Live Photos and newer
+# devices can easily exceed 50MB even when they appear "small" in the photo
+# picker, so allow up to 150MB to avoid spurious 413 errors while still
+# preventing runaway uploads.
+app.config['MAX_CONTENT_LENGTH'] = 150 * 1024 * 1024  # 150MB limit
 app.config['UPLOAD_TIMEOUT'] = 300  # 5 minutes
 
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- raise the Flask MAX_CONTENT_LENGTH to 150MB so moderate media uploads no longer trigger 413 errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69067d196994832c9e317b1b7992e934