### PR TITLE
Allow bearer tokens for session lookup

### DIFF
--- a/app.py
+++ b/app.py
@@ -586,7 +586,11 @@ def clear_session_cookie(resp):
 def current_user_row() -> Optional[Dict[str, Any]]:
     token = request.cookies.get("kinjar_session")
     if not token:
-        return None
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            token = auth_header[len("Bearer ") :].strip()
+        if not token:
+            return None
     payload = verify_jwt(token)
     if not payload or "uid" not in payload:
         return None


### PR DESCRIPTION
## Summary
- allow the backend to recognize Bearer tokens when no session cookie is present
- support the frontend's localStorage token usage so that authenticated requests succeed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907a289746c832ca02eea0d1d504681