### PR TITLE
Add post deletion API and frontend management UI

### DIFF
--- a/frontend-deploy/src/app/page.tsx
+++ b/frontend-deploy/src/app/page.tsx
@@ -1,7 +1,16 @@
+"use client";
+
 import Link from 'next/link'
+import FamilyFeed from '../components/FamilyFeed'
 import { useAuth } from '../lib/auth'
 
 export default function HomePage() {
+  const { isAuthenticated } = useAuth()
+
+  if (isAuthenticated) {
+    return <FamilyFeed />
+  }
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
       {/* Navigation */}

--- a/frontend-deploy/src/components/FamilyFeed.tsx
+++ b/frontend-deploy/src/components/FamilyFeed.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { api, Post, getSubdomainInfo } from '../lib/api';
+import { useAuth } from '../lib/auth';
+
+function formatTimestamp(timestamp: string): string {
+  if (!timestamp) {
+    return '';
+  }
+
+  try {
+    const date = new Date(timestamp);
+    return isNaN(date.getTime()) ? timestamp : date.toLocaleString();
+  } catch {
+    return timestamp;
+  }
+}
+
+function MediaPreview({ media }: { media: Post['media'] }) {
+  if (!media) {
+    return null;
+  }
+
+  if (media.type === 'image') {
+    return (
+      <img
+        src={media.url}
+        alt={media.alt || 'Post media'}
+        className="mt-4 w-full rounded-lg object-cover"
+      />
+    );
+  }
+
+  if (media.type === 'video') {
+    return (
+      <video
+        src={media.url}
+        controls
+        className="mt-4 w-full rounded-lg"
+      />
+    );
+  }
+
+  return null;
+}
+
+export default function FamilyFeed() {
+  const { user, loading: authLoading } = useAuth();
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deletingPostId, setDeletingPostId] = useState<string | null>(null);
+  const [familySlug, setFamilySlug] = useState<string | null>(null);
+
+  useEffect(() => {
+    const info = getSubdomainInfo();
+    if (info.isSubdomain && info.familySlug) {
+      setFamilySlug(info.familySlug);
+    } else {
+      setError('Visit your family subdomain to view posts.');
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!familySlug) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadPosts = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const fetched = await api.getFamilyPosts(familySlug);
+        if (!cancelled) {
+          setPosts(fetched);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const message = err instanceof Error ? err.message : 'Failed to load posts';
+          setError(message);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadPosts();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [familySlug]);
+
+  const membershipRole = useMemo(() => {
+    if (!user || !familySlug) {
+      return null;
+    }
+
+    const membership = user.memberships.find((m) => m.familySlug === familySlug);
+    return membership?.role ?? null;
+  }, [user, familySlug]);
+
+  const canManagePosts = useMemo(() => {
+    if (!user) {
+      return () => false;
+    }
+
+    const isAdmin = membershipRole === 'ADMIN' || membershipRole === 'OWNER' || user.globalRole === 'ROOT_ADMIN';
+
+    return (post: Post) => {
+      if (!user) {
+        return false;
+      }
+      return isAdmin || post.authorId === user.id;
+    };
+  }, [user, membershipRole]);
+
+  const handleDelete = async (postId: string) => {
+    if (!familySlug || deletingPostId) {
+      return;
+    }
+
+    const post = posts.find((item) => item.id === postId);
+    if (post && !canManagePosts(post)) {
+      setError('You do not have permission to delete this post.');
+      return;
+    }
+
+    if (typeof window !== 'undefined') {
+      const confirmed = window.confirm('Are you sure you want to delete this post?');
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    setDeletingPostId(postId);
+
+    try {
+      await api.deletePost(postId, familySlug);
+      setPosts((prev) => prev.filter((item) => item.id !== postId));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete post';
+      setError(message);
+    } finally {
+      setDeletingPostId(null);
+    }
+  };
+
+  const showLoading = loading || authLoading;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 py-10">
+      <div className="max-w-4xl mx-auto px-4 space-y-6">
+        <header className="flex flex-col gap-2">
+          <h1 className="text-3xl font-bold text-gray-900">Family Posts</h1>
+          {familySlug && (
+            <p className="text-sm text-gray-600">Showing posts for <span className="font-medium">{familySlug}</span></p>
+          )}
+        </header>
+
+        {error && (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {showLoading && (
+          <div className="rounded-lg border border-gray-200 bg-white px-4 py-8 text-center text-gray-500 shadow-sm">
+            Loading posts...
+          </div>
+        )}
+
+        {!showLoading && posts.length === 0 && !error && (
+          <div className="rounded-lg border border-gray-200 bg-white px-4 py-8 text-center text-gray-500 shadow-sm">
+            No posts have been shared yet.
+          </div>
+        )}
+
+        {!showLoading && posts.map((post) => (
+          <article key={post.id} className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">{post.authorName}</h2>
+                <p className="text-sm text-gray-500">{formatTimestamp(post.createdAt)}</p>
+              </div>
+              {canManagePosts(post) && (
+                <button
+                  onClick={() => handleDelete(post.id)}
+                  disabled={deletingPostId === post.id}
+                  className="rounded-md border border-red-200 bg-red-50 px-3 py-1 text-sm font-medium text-red-600 transition hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {deletingPostId === post.id ? 'Deleting...' : 'Delete'}
+                </button>
+              )}
+            </div>
+
+            <p className="mt-4 whitespace-pre-line text-gray-700">{post.content}</p>
+
+            <MediaPreview media={post.media} />
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend-deploy/src/lib/auth.tsx
+++ b/frontend-deploy/src/lib/auth.tsx
@@ -83,8 +83,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     register,
     logout,
     isAuthenticated: !!user,
-    isRootAdmin: user?.role === 'root_admin',
-    isFamilyAdmin: user?.role === 'family_admin' || user?.role === 'root_admin',
+    isRootAdmin: user?.globalRole === 'ROOT_ADMIN',
+    isFamilyAdmin:
+      !!user && (
+        user.globalRole === 'ROOT_ADMIN' ||
+        user.memberships.some((membership) => membership.role === 'ADMIN' || membership.role === 'OWNER')
+      ),
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend-deploy/src/types/index.ts
+++ b/frontend-deploy/src/types/index.ts
@@ -1,0 +1,81 @@
+export interface SubdomainInfo {
+  isSubdomain: boolean;
+  subdomain?: string;
+  familySlug?: string;
+  isRootDomain: boolean;
+}
+
+export interface MembershipInfo {
+  familyId: string;
+  familySlug: string;
+  familyName: string;
+  role: 'OWNER' | 'ADMIN' | 'MEMBER';
+  joinedAt: string | null;
+}
+
+export interface AuthUser {
+  id: string;
+  name: string;
+  email: string;
+  avatarColor?: string;
+  globalRole: 'ROOT_ADMIN' | 'FAMILY_ADMIN' | 'MEMBER';
+  memberships: MembershipInfo[];
+  createdAt?: string | null;
+  lastLoginAt?: string | null;
+}
+
+export type User = AuthUser;
+
+export interface CreateFamilyRequest {
+  name: string;
+  slug?: string;
+  description?: string;
+}
+
+export interface FamilyProfile {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface InviteMemberRequest {
+  email: string;
+  role?: 'MEMBER' | 'ADMIN' | 'OWNER';
+  message?: string;
+}
+
+export interface MediaAttachment {
+  id?: string;
+  url: string;
+  type: 'image' | 'video';
+  alt?: string;
+  thumbnailUrl?: string;
+}
+
+export interface PostComment {
+  id: string;
+  authorId: string;
+  authorName?: string;
+  authorAvatarColor?: string;
+  content: string;
+  createdAt: string;
+}
+
+export interface FamilyPost {
+  id: string;
+  familyId: string;
+  authorId: string;
+  authorName: string;
+  authorAvatarColor?: string;
+  createdAt: string;
+  content: string;
+  media?: MediaAttachment;
+  visibility: 'family' | 'connections' | 'public';
+  status: string;
+  reactions: number;
+  comments: PostComment[];
+  tags: string[];
+}


### PR DESCRIPTION
## Summary
- add a DELETE /api/posts/<post_id> endpoint that validates tenant context, checks permissions, and removes related media
- expand the frontend API client and auth utilities to understand the new response patterns and expose deletePost
- create a FamilyFeed view with delete controls and surface it for authenticated users

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_690924cda47c832c8c3a2ce675e56674